### PR TITLE
chore: pkg-pr-new

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,39 @@
+name: pkg-pr-new
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  pkg_pr_new:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+        shell: bash
+
+      - name: build (experimental)
+        run: |
+          RELEASE_CHANNEL=experimental yarn --cwd fixtures/flight-vite build-dep
+          sed -i 's/"name": "react-server-dom-vite"/"name": "react-server-dom-vite-experimental"/' build/node_modules/react-server-dom-vite/package.json
+          cp -rf build/node_modules/react-server-dom-vite pkg-react-server-dom-vite-experimental
+
+      - name: build (stable)
+        run: |
+          RELEASE_CHANNEL=stable yarn --cwd fixtures/flight-vite build-dep
+          cp -rf build/node_modules/react-server-dom-vite pkg-react-server-dom-vite
+
+      - name: pkg-pr-new
+        run: |
+          npx pkg-pr-new publish --comment=off \
+            pkg-react-server-dom-vite \
+            pkg-react-server-dom-vite-experimental


### PR DESCRIPTION
_todo_
- [x] experimental
- [x] stable
- ~[ ] backport to 19.1 (or stable is enough?)~

```sh
npm i https://pkg.pr.new/hi-ogawa/react/react-server-dom-vite@7f9931b
npm i https://pkg.pr.new/hi-ogawa/react/react-server-dom-vite-experimental@7f9931b
```